### PR TITLE
Increse max_length of Card.name

### DIFF
--- a/src/magic_cards/migrations/0001_initial.py
+++ b/src/magic_cards/migrations/0001_initial.py
@@ -27,7 +27,7 @@ class Migration(migrations.Migration):
             name='Card',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('name', models.CharField(max_length=127, unique=True)),
+                ('name', models.CharField(max_length=255, unique=True)),
                 ('mana_cost', models.CharField(blank=True, max_length=63)),
                 ('text', models.TextField(blank=True)),
                 ('power', models.CharField(blank=True, max_length=7)),

--- a/src/magic_cards/models.py
+++ b/src/magic_cards/models.py
@@ -10,7 +10,7 @@ class NameMixin(object):
 
 
 class Card(NameMixin, models.Model):
-    name = models.CharField(max_length=127, unique=True)
+    name = models.CharField(max_length=255, unique=True)
     mana_cost = models.CharField(max_length=63, blank=True)
 
     supertypes = models.ManyToManyField('CardSupertype')

--- a/tests/models/tests.py
+++ b/tests/models/tests.py
@@ -1,0 +1,20 @@
+from django.test import TestCase
+
+from magic_cards.models import Card
+from magic_cards.utils.initial_import import import_cards
+
+
+class ImportScriptTests(TestCase):
+    def test_long_card_name(self):
+        """
+        The longest card name can be successfully imported and stored fully in the database.
+        """
+        import_cards(["UNH"])
+
+        longest_name = "Our Market Research Shows That Players Like Really Long Card Names " \
+                       "So We Made this Card to Have the Absolute Longest Card Name Ever Elemental"
+        longest_name_card = Card.objects.get(name=longest_name)
+        self.assertEqual(longest_name_card.name, longest_name)
+        # SQLite does not actually enforce the length of a VARCHAR, but Django will validate
+        # if we call full_clean.
+        longest_name_card.full_clean()


### PR DESCRIPTION
[One card](http://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=74237) has a name that's 142 characters long, so max_length=127 is insufficient.

Since it's so early in the app's lifecycle, I've edited the initial migration in-place, rather than make a second migration.

Fixes #2.