### PR TITLE
Speed up initial import script

### DIFF
--- a/src/magic_cards/utils/initial_import.py
+++ b/src/magic_cards/utils/initial_import.py
@@ -151,6 +151,17 @@ def parse_data(sets_data, set_codes):
         if printings_to_create:
             Printing.objects.bulk_create(printings_to_create)
 
+    # Remove extra Printings caused by data that is duplicated on MTGJSON.
+    # https://github.com/mtgjson/mtgjson/issues/388
+    if set_codes is Everything or 'BOK' in set_codes:
+        bugged_card_names = ['Jaraku the Interloper', 'Scarmaker']
+        for name in bugged_card_names:
+            extra_printings = Printing.objects.filter(
+                set__code='BOK', card__name=name)[1:].values_list(
+                    'pk', flat=True)
+            Printing.objects.filter(pk__in=list(extra_printings)).delete()
+
+
 @transaction.atomic
 def import_cards(set_codes=Everything):
     sets_data = fetch_data()

--- a/src/magic_cards/utils/initial_import.py
+++ b/src/magic_cards/utils/initial_import.py
@@ -49,11 +49,21 @@ def parse_rarity(string):
         return Printing.Rarity.SPECIAL
 
 
+class ModelCache(dict):
+
+    def get_or_create(self, model, field, value):
+        result = self[model].get(value)
+        if not result:
+            result = model.objects.create(**{field: value})
+            self[model][value] = result
+        return result
+
+
 def parse_data(sets_data, set_codes):
     # Load supertypes, types, and subtypes into memory
-    supertype_objs = {t.name: t for t in CardSupertype.objects.all()}
-    type_objs = {t.name: t for t in CardType.objects.all()}
-    subtype_objs = {t.name: t for t in CardSubtype.objects.all()}
+    cache = ModelCache()
+    for model in [CardSupertype, CardType, CardSubtype]:
+        cache[model] = {obj.name: obj for obj in model.objects.all()}
 
     # Process the data set-by-set
     for code, data in sets_data.items():
@@ -90,25 +100,13 @@ def parse_data(sets_data, set_codes):
             types = card_data['types']
             subtypes = card_data.get('subtypes', [])
             for supertype_name in supertypes:
-                if supertype_name in supertype_objs:
-                    supertype = supertype_objs[supertype_name]
-                else:
-                    supertype = CardSupertype.objects.create(name=supertype_name)
-                    supertype_objs[supertype_name] = supertype
+                supertype = cache.get_or_create(CardSupertype, 'name', supertype_name)
                 card.supertypes.add(supertype)
             for type_name in types:
-                if type_name in type_objs:
-                    card_type = type_objs[type_name]
-                else:
-                    card_type = CardType.objects.create(name=type_name)
-                    type_objs[type_name] = card_type
+                card_type = cache.get_or_create(CardType, 'name', type_name)
                 card.types.add(card_type)
             for subtype_name in subtypes:
-                if subtype_name in subtype_objs:
-                    subtype = subtype_objs[subtype_name]
-                else:
-                    subtype = CardSubtype.objects.create(name=subtype_name)
-                    subtype_objs[subtype_name] = subtype
+                subtype = cache.get_or_create(CardSubtype, 'name', subtype_name)
                 card.subtypes.add(subtype)
 
             # Printing info

--- a/src/magic_cards/utils/initial_import.py
+++ b/src/magic_cards/utils/initial_import.py
@@ -74,6 +74,11 @@ def parse_data(sets_data, set_codes):
     cache = ModelCache()
     for model in [CardSupertype, CardType, CardSubtype]:
         cache[model] = {obj.name: obj for obj in model.objects.all()}
+    # Load relevant sets into memory
+    if set_codes is Everything:
+        cache[Set] = {obj.code: obj for obj in Set.objects.all()}
+    else:
+        cache[Set] = {obj.code: obj for obj in Set.objects.filter(code__in=set_codes)}
 
     # Process the data set-by-set
     for code, data in sets_data.items():
@@ -83,7 +88,7 @@ def parse_data(sets_data, set_codes):
             continue
 
         # Create the set
-        magic_set, _ = Set.objects.get_or_create(code=code, name=data['name'])
+        magic_set, set_created = cache.get_or_create(Set, 'code', code, name=data['name'])
 
         # Create cards
         all_cards_data = data['cards']

--- a/src/magic_cards/utils/initial_import.py
+++ b/src/magic_cards/utils/initial_import.py
@@ -50,6 +50,11 @@ def parse_rarity(string):
 
 
 def parse_data(sets_data, set_codes):
+    # Load supertypes, types, and subtypes into memory
+    supertype_objs = {t.name: t for t in CardSupertype.objects.all()}
+    type_objs = {t.name: t for t in CardType.objects.all()}
+    subtype_objs = {t.name: t for t in CardSubtype.objects.all()}
+
     # Process the data set-by-set
     for code, data in sets_data.items():
 
@@ -85,13 +90,25 @@ def parse_data(sets_data, set_codes):
             types = card_data['types']
             subtypes = card_data.get('subtypes', [])
             for supertype_name in supertypes:
-                supertype, _ = CardSupertype.objects.get_or_create(name=supertype_name)
+                if supertype_name in supertype_objs:
+                    supertype = supertype_objs[supertype_name]
+                else:
+                    supertype = CardSupertype.objects.create(name=supertype_name)
+                    supertype_objs[supertype_name] = supertype
                 card.supertypes.add(supertype)
             for type_name in types:
-                card_type, _ = CardType.objects.get_or_create(name=type_name)
+                if type_name in type_objs:
+                    card_type = type_objs[type_name]
+                else:
+                    card_type = CardType.objects.create(name=type_name)
+                    type_objs[type_name] = card_type
                 card.types.add(card_type)
             for subtype_name in subtypes:
-                subtype, _ = CardSubtype.objects.get_or_create(name=subtype_name)
+                if subtype_name in subtype_objs:
+                    subtype = subtype_objs[subtype_name]
+                else:
+                    subtype = CardSubtype.objects.create(name=subtype_name)
+                    subtype_objs[subtype_name] = subtype
                 card.subtypes.add(subtype)
 
             # Printing info

--- a/src/magic_cards/utils/initial_import.py
+++ b/src/magic_cards/utils/initial_import.py
@@ -51,15 +51,19 @@ def parse_rarity(string):
 
 class ModelCache(dict):
 
-    def get_or_create(self, model, field, value):
+    def get_or_create(self, model, field, value, **kwargs):
         """
-        Returns a tuple of (object, created), where created is a boolean specifying whether an
-        object was created.
+        Retrieves object of class `model` with lookup key `value` from the cache. If not found,
+        creates the object based on `field=value` and any other `kwargs`.
+
+        Returns a tuple of `(object, created)`, where `created` is a boolean specifying whether an
+        `object` was created.
         """
         result = self[model].get(value)
         created = False
         if not result:
-            result = model.objects.create(**{field: value})
+            kwargs[field] = value
+            result = model.objects.create(**kwargs)
             self[model][value] = result
             created = True
         return result, created

--- a/src/magic_cards/utils/initial_import.py
+++ b/src/magic_cards/utils/initial_import.py
@@ -52,11 +52,17 @@ def parse_rarity(string):
 class ModelCache(dict):
 
     def get_or_create(self, model, field, value):
+        """
+        Returns a tuple of (object, created), where created is a boolean specifying whether an
+        object was created.
+        """
         result = self[model].get(value)
+        created = False
         if not result:
             result = model.objects.create(**{field: value})
             self[model][value] = result
-        return result
+            created = True
+        return result, created
 
 
 def parse_data(sets_data, set_codes):
@@ -100,13 +106,13 @@ def parse_data(sets_data, set_codes):
             types = card_data['types']
             subtypes = card_data.get('subtypes', [])
             for supertype_name in supertypes:
-                supertype = cache.get_or_create(CardSupertype, 'name', supertype_name)
+                supertype, _ = cache.get_or_create(CardSupertype, 'name', supertype_name)
                 card.supertypes.add(supertype)
             for type_name in types:
-                card_type = cache.get_or_create(CardType, 'name', type_name)
+                card_type, _ = cache.get_or_create(CardType, 'name', type_name)
                 card.types.add(card_type)
             for subtype_name in subtypes:
-                subtype = cache.get_or_create(CardSubtype, 'name', subtype_name)
+                subtype, _ = cache.get_or_create(CardSubtype, 'name', subtype_name)
                 card.subtypes.add(subtype)
 
             # Printing info

--- a/tests/utils/tests.py
+++ b/tests/utils/tests.py
@@ -16,7 +16,8 @@ class ImportTestBase:
         # Only the basic lands should have multiple printings.
         multiple_printings = Card.objects.annotate(count=Count('printings')).filter(count__gte=2)
         basic_lands = {'Forest', 'Island', 'Mountain', 'Plains', 'Swamp'}
-        self.assertQuerysetEqual(multiple_printings, basic_lands, ordered=False, transform=lambda x: x.name)
+        if multiple_printings:
+            self.assertQuerysetEqual(multiple_printings, basic_lands, ordered=False, transform=lambda x: x.name)
 
         # Every printing has a rarity.
         self.assertFalse(Printing.objects.filter(rarity__isnull=True))

--- a/tests/utils/tests.py
+++ b/tests/utils/tests.py
@@ -85,6 +85,25 @@ class ImportScriptTests(ImportTestBase, TestCase):
         self.assertEqual(Card.objects.count(), 287)
         self.assertEqual(Printing.objects.count(), 302)
 
+    def test_import_betrayers(self):
+        """
+        Data integrity issues from a bug in MTGJSON are cleaned up by the import process.
+        """
+        import_cards(["BOK"])
+
+        self.assertEqual(Set.objects.count(), 1)
+        betrayers = Set.objects.first()
+        self.assertEqual(betrayers.name, "Betrayers of Kamigawa")
+        self.assertEqual(betrayers.code, "BOK")
+
+        self.assertEqual(Card.objects.count(), 170)
+        #   170 Distinctly-named cards
+
+        self.assertEqual(Printing.objects.count(), 170)
+        #   170 Number of cards
+        # +   0 Basic lands
+
+        self.check_common_set_constraints()
 
 class ImportManagementCommandTests(ImportTestBase, TestCase):
 

--- a/tests/utils/tests.py
+++ b/tests/utils/tests.py
@@ -34,7 +34,7 @@ class ImportScriptTests(ImportTestBase, TestCase):
 
         self.assertEqual(Set.objects.count(), 212)
         self.assertEqual(Card.objects.count(), 17422)
-        self.assertEqual(Printing.objects.count(), 33840)
+        self.assertEqual(Printing.objects.count(), 33860)
 
     def test_import_single_set(self):
         import_cards(["SOM"])


### PR DESCRIPTION
Improves the speed of the initial import script by loading various objects into memory, rather than continually calling `get_or_create`.

Partially addresses #9.