### PR TITLE
Test importing all cards only on latest Python and Django versions

### DIFF
--- a/tests/utils/tests.py
+++ b/tests/utils/tests.py
@@ -1,6 +1,7 @@
 import copy
 import json
 import os
+import unittest
 
 from django.core.management import call_command
 from django.db.models import Count
@@ -37,6 +38,15 @@ class ImportTestBase:
 
 class ImportScriptTests(ImportTestBase, TestCase):
 
+    @unittest.skipIf(
+        all([
+            os.environ.get("TRAVIS", False),
+            any([
+                os.environ.get("DJANGO", None) != '1.11',
+                os.environ.get("TRAVIS_PYTHON_VERSION", None) != '3.6',
+            ]),
+        ]),
+        "On Travis, only runs on Django 1.11 under Python 3.6")
     def test_import_all_cards(self):
         import_cards()
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ DJANGO =
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/magic_cards
+passenv = TRAVIS DJANGO TRAVIS_PYTHON_VERSION
 commands = coverage run --parallel runtests.py
 deps =
     django18: Django>=1.8,<1.9


### PR DESCRIPTION
`tests.utils.tests.ImportScriptTests.test_import_all_cards` takes several minutes to run, resulting in a ~20-30 minute test suite on Travis. This commit restricts that test to run only on the latest Python/Django combination (currently set as 3.6 and 1.11) when CI is performed on Travis, giving us a test suite that takes <10 minutes of clock time.

(When `tox` is run outside Travis, all tests will be run for all Python/Django combinations.)