### PR TITLE
Django 2.0 support - add `on_delete` attributes

### DIFF
--- a/src/magic_cards/models.py
+++ b/src/magic_cards/models.py
@@ -52,11 +52,17 @@ class Printing(models.Model):
 
     objects = PrintingQuerySet.as_manager()
 
-    card = models.ForeignKey('Card', related_name='printings')
-    set = models.ForeignKey('Set', related_name='printings')
+    card = models.ForeignKey('Card',
+                             on_delete=models.CASCADE,
+                             related_name='printings')
+    set = models.ForeignKey('Set',
+                            on_delete=models.CASCADE,
+                            related_name='printings')
     rarity = enum.EnumField(Rarity)
     flavor_text = models.TextField(blank=True)
-    artist = models.ForeignKey('Artist', related_name='printings')
+    artist = models.ForeignKey('Artist',
+                               on_delete=models.CASCADE,
+                               related_name='printings')
     number = models.CharField(max_length=7, blank=True)
     multiverse_id = models.PositiveIntegerField(blank=True, null=True)
 


### PR DESCRIPTION
This patch adds the "on_delete" attribute to ForeignKeys as required
by Django >= 2.0. Defaults to the CASCADE behavior, which was the
default in 1.X.